### PR TITLE
tbats 1.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,38 +6,42 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/tbats-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: dccd0d4cd9e2fde30bf19a944ee957d2f865975846284f48ce673992c4f5d89e
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
     - pip
-    - pytest
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
+    - python
     - numpy
     - pmdarima
-    - python >=3.6
     - scikit-learn
     - scipy
 
 test:
   imports:
     - tbats
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/intive-DataScience/tbats
+  dev_url: https://github.com/intive-DataScience/tbats
+  doc_url: https://github.com/intive-DataScience/tbats
   summary: BATS and TBATS for time series forecasting
+  description: BATS and TBATS for time series forecasting
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
Changelog: https://github.com/intive-DataScience/tbats/releases
License:  https://github.com/intive-DataScience/tbats/blob/1.1.3/LICENSE
Requirements: https://github.com/intive-DataScience/tbats/blob/1.1.3/setup.py

Actions:
1. Remove `noarch python`
2. Add flags `--no-deps --no-build-isolation` to `script`
3. Add missing `setuptools` and `wheel` to `host`
4. Fix `python` in `host` and `run`
5. Add dev & doc urls
6. Add `description` 
7. Add `license_family`

Notes:
- pycaret 3.0.2 relies on it https://github.com/pycaret/pycaret/blob/fdc3f7d22a4117577340be6d8fe2db2a889e9d82/requirements.txt#L39